### PR TITLE
Fix invalid rewrite configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,8 +7,8 @@ const nextConfig = {
       {
         source: '/api/:path*',
         destination: process.env.NODE_ENV === 'production' 
-          ? `${process.env.BACKEND_URL}/api/:path*`
-          : 'http://localhost:8000/:path*',
+          ? `${process.env.BACKEND_URL || 'http://localhost:8000'}/api/:path*`
+          : 'http://localhost:8000/api/:path*',
       },
     ];
   },


### PR DESCRIPTION
Fix build error caused by undefined `BACKEND_URL` in Next.js rewrite configuration.

The `destination` for `/api/:path*` rewrites was `undefined/api/:path*` when `process.env.BACKEND_URL` was not set during build. This PR adds a fallback to `http://localhost:8000` for production and corrects the development URL to include `/api`.